### PR TITLE
Correcting Script URL to point to mouse.js

### DIFF
--- a/tests/engine/interaction/pointer/laser/mouse/testStory.md
+++ b/tests/engine/interaction/pointer/laser/mouse/testStory.md
@@ -6,7 +6,7 @@ Interface is running in an empty domain where you have edit rights.
 ### Steps
 
 #### Step 1
-- Run the [mouse.js script](./renderState.js?raw=true) (from Menu/Edit/Open and Run scripts From URL...).  Move your mouse on and off the wall.
+- Run the [mouse.js script](./mouse.js) (from Menu/Edit/Open and Run scripts From URL...).  Move your mouse on and off the wall.
 - Expected:
 ![](./mouse1.jpg)
 ![](./mouse2.jpg)


### PR DESCRIPTION
Script URL in step 1 pointed to renderState.js. This just changes to the appropriate mouse.js